### PR TITLE
Bug fixes around advanced function resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 0.0.6
+ * Fix bug where things like sinon.stub cause dependency check to throw an exception
+ * When a function's dependencies cannot be resolved, return the function rather than throw an exception

--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ fount.register( 'port', 8080 );
 ```
 
 ### function
-Registering a function with fount will cause it to invoke the function during resolution and return the result.
+Registering a function with fount will cause it to invoke the function during resolution and return the result with two exceptions:
+
+ 1. The function is a stub or some other abstraction that cannot have dependencies resolved for it
+ 2. The function has dependencies which do not exist for fount
+
+In these exceptional scenarios, fount will resolve the dependency with the function itself rather than calling it for you.
 
 ```javascript
 fount.register( 'factory', function() { return 'a thing!' } );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fount",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A source from which dependencies flow",
   "main": "./src/index.js",
   "scripts": {
@@ -30,6 +30,7 @@
   "devDependencies": {
     "gulp": "^3.8.6",
     "gulp-mocha": "^0.5.1",
-    "should": "^4.0.4"
+    "should": "^4.0.4",
+    "sinon": "^1.12.1"
   }
 }

--- a/spec/fount.spec.js
+++ b/spec/fount.spec.js
@@ -1,6 +1,7 @@
 var should = require( 'should' );
 var when = require( 'when' );
 var fount = require( '../src/index.js' );
+var sinon = require( 'sinon' );
 
 describe( 'when resolving values', function() {
 	var result;
@@ -16,6 +17,42 @@ describe( 'when resolving values', function() {
 
 	it( 'should resolve correctly', function() {
 		result.should.equal( 'ohhai' );
+	} );
+} );
+
+describe( 'when resolving sinon.stub', function() {
+	var stub = sinon.stub();	
+	var result;
+
+	before( function( done ) {
+		fount.register( 'aStub', stub );
+		fount.inject( function( aStub ) {
+			result = aStub;
+			done();
+		} );
+	} );
+
+	it( 'should resolve the stub as a function', function() {
+		result.should.eql( stub );
+	} );
+} );
+
+describe( 'when resolving a function with unresolvable dependencies', function() {
+	var fn = function( x, y, z ) {
+		return x + y + z;
+	};	
+	var result;
+
+	before( function( done ) {
+		fount.register( 'unresolvable', fn );
+		fount.inject( function( unresolvable ) {
+			result = unresolvable( 1, 2, 3 );
+			done();
+		} );
+	} );
+
+	it( 'should resolve the stub as a function', function() {
+		result.should.eql( 6 );
 	} );
 } );
 


### PR DESCRIPTION
- Now supports sinon stubs as dependencies
- Will return function dependency directly when the function's dependencies/arguments cannot be resolved
- No longer throw exceptions when a function's `.toString()` results in an unexpected format
