### PR TITLE
Better error handling, canResolve, NPM module dependencies, bulk registration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 demo/
 tmp/
 node_modules/
+coverage/
+spec/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.X
+
+### 0.1.0
+
+ * #7 - Add better error reporting - include all unresolvable keys
+ * #6 - Export canResolve to allow consumers to check in advance
+ * Backfill dependencies from NPM modules when available
+ * Add support for bulk registration
+
+## 0.0.X
+
 ### 0.0.6
  * Fix bug where things like sinon.stub cause dependency check to throw an exception
  * When a function's dependencies cannot be resolved, return the function rather than throw an exception

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ fount.resolve( [ 'a.one', 'b.two' ] ).then( function( results ) {
 } );
 ```
 
+You can also check in advance whether or not fount is able to resolve a dependency using `canResolve`:
+
+```javascript
+fount.canResolve( 'key1' );
+
+fount.canResolve( [ 'key1', 'key2' ] );
+```
+
 ## Injecting
 Injecting is how you get fount to invoke a function on your behalf with resolved dependencies. If you're familiar with AMD, it's somewhat similar to how define works.
 
@@ -153,6 +161,46 @@ fount.inject( [ 'a', 'b' ], function( a, b )  { ... }, 'myScope' );
 
 // using keys across multiple containers
 fount.inject( [ 'one.a', 'two.b' ], function( a, b ) { ... } );
+
+// alternate support for multiple containers
+fount.inject( function( one_a, two_b ) { ... } );
+```
+
+## Configuration
+Configuration of multiple containers, keys and values can be accomplished via a configuration hash passed to fount. The format of the hash is as follows:
+
+```javascript
+{
+	[containerName]: {
+		[keyName]: [value],
+		[keyName]: {
+			[scope]: [value]
+		}
+	}
+}
+```
+
+__example__
+```javascript
+fount( {
+	default: {
+		a: 1,
+		b: function() {
+			return 2;
+		}
+	},
+	other: {
+		c: { scoped: 3 },
+		d: { scoped: function() {
+				return 4;
+			}
+		},
+		e: { static: 5 },
+		f: { factory: function() {
+				return 6;
+			} }
+	}
+} );
 ```
 
 ## Diagnostic
@@ -163,6 +211,3 @@ Right now this is pretty weak, but if you call `log`, Fount will dump the contai
 * Running `gulp` starts both the `test` and `watch` tasks, so you'll see the tests re-run any time you save a file under `src/` or `spec/`.
 * Running `gulp coverage` will run istanbul and create a `coverage/` folder.
 * Running `gulp show-coverage` will run istanbul and open the browser-based coverage report.
-
-## Things to do soon
- * Good error handling - returning clear error messages when a resolution/injection fails

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,36 +1,26 @@
 var gulp = require( 'gulp' );
-var mocha = require( 'gulp-mocha' );
-var istanbul = require( 'gulp-istanbul' );
-var open = require( 'open' );
-var allSrcFiles = './src/**/*.js';
-var allSpecFiles = './spec/*.spec.js';
+var bg = require( 'biggulp' )( gulp );
 
-gulp.task( 'test', function() {
-	gulp.src( allSpecFiles )
-		.pipe( mocha( { reporter: 'spec' } ) )
-		.on( 'error', function( err ) {
-			console.log( err.stack );
-		} );
+gulp.task( 'coverage', bg.withCoverage() );
+
+gulp.task( 'coverage-watch', function() {
+	bg.watch( [ 'coverage' ] );
 } );
 
-gulp.task( 'coverage', function( cb ) {
-	return gulp.src( [ allSrcFiles ] )
-		.pipe( istanbul() )
-		.pipe( istanbul.hookRequire() )
-		.on( 'finish', function() {
-			gulp.src( [ allSpecFiles ] )
-				.pipe( mocha() )
-				.pipe( istanbul.writeReports() );
-		} );
+gulp.task( 'show-coverage', bg.showCoverage() );
+
+gulp.task( 'continuous-specs', function() {
+	return bg.test();
 } );
 
-gulp.task( 'show-coverage', [ 'coverage' ], function( cb ) {
-	open( './coverage/lcov-report/index.html' );
-	cb();
+gulp.task( 'specs-watch', function() {
+	bg.watch( [ 'continuous-specs' ] );
 } );
 
-gulp.task( 'watch', function() {
-	gulp.watch( [ allSrcFiles, './spec/**' ], [ 'test' ] );
+gulp.task( 'test-and-exit', function() {
+	return bg.testOnce();
 } );
 
-gulp.task( 'default', [ 'test', 'watch' ], function() {} );
+gulp.task( 'default', [ 'coverage', 'coverage-watch' ], function() {} );
+gulp.task( 'specs', [ 'continuous-specs', 'specs-watch' ], function() {} );
+gulp.task( 'test', [ 'test-and-exit' ] );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fount",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "A source from which dependencies flow",
   "main": "./src/index.js",
   "scripts": {
@@ -23,18 +23,17 @@
   },
   "homepage": "https://github.com/LeanKit-Labs/fount",
   "dependencies": {
-    "debug": "^1.0.4",
-    "lodash": "^2.4.1",
-    "when": "^3.3.1"
+    "debug": "^2.1.3",
+    "lodash": "^3.7.0",
+    "when": "^3.7.2",
+    "whistlepunk": "^0.3.1"
   },
   "devDependencies": {
-    "chai": "^2.1.0",
-    "chai-as-promised": "^4.2.0",
-    "gulp": "^3.8.6",
-    "gulp-istanbul": "^0.6.0",
-    "gulp-mocha": "2.0.x",
-    "should": "^5.0.1",
-    "sinon": "^1.12.1",
-    "sinon-chai": "^2.7.0"
+    "biggulp": "~0.0.2",
+    "chai": "~2.1.1",
+    "chai-as-promised": "~4.3.0",
+    "gulp": "~3.8.11",
+    "postal": "^1.0.2",
+    "sinon": "~1.14.1"
   }
 }

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,0 +1,21 @@
+var chai = require( 'chai' );
+chai.use( require( 'chai-as-promised' ) );
+global.should = chai.should();
+global.expect = chai.expect;
+global._ = require( 'lodash' );
+global.sinon = require( 'sinon' );
+global.when = require( 'when' );
+
+var fs = require( 'fs' );
+var path = require( 'path' );
+
+function findParent( mod ) {
+	if ( mod.parent ) {
+		return findParent( mod.parent );
+	} else {
+		return mod;
+	}
+}
+
+var parent = findParent( module );
+parent.paths.push( path.join( process.cwd(), 'node_modules' ) );

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,31 @@ var when = require( 'when' );
 var whenFn = require( 'when/function' );
 var whenKeys = require( 'when/keys' );
 var debug = require( 'debug' )( 'fount' );
-
+var util = require( 'util' );
+var path = require( 'path' );
+var fs = require( 'fs' );
 var containers = {};
+var parent;
+var getDisplay = process.env.DEBUG ? displayDependency : _.noop;
+
+function backfillMissingDependency( name, containerName ) {
+	var mod = getLoadedModule( name ) || getModuleFromInstalls( name );
+	if ( mod ) {
+		var lifecycle = _.isFunction( mod ) ? 'factory' : 'static';
+		register( containerName, name, mod, lifecycle );
+	} else {
+		debug( 'Could not backfill dependency %s in in container %s', name, containerName );
+	}
+	return mod;
+}
+
+function canResolve( containerName, dependencies, scopeName ) {
+	return getMissingDependencies( containerName, dependencies, scopeName ).length === 0;
+}
 
 function checkDependencies( fn, dependencies ) {
 	var fnString = fn.toString();
-	if( /[(][^)]*[)]/.test( fnString ) ) {
+	if ( /[(][^)]*[)]/.test( fnString ) ) {
 		return ( _.isFunction( fn ) && !dependencies.length ) ?
 			trim( /[(]([^)]*)[)]/.exec( fnString )[ 1 ].split( ',' ) ) :
 			dependencies;
@@ -17,25 +36,146 @@ function checkDependencies( fn, dependencies ) {
 	}
 }
 
+function configure( config ) {
+	_.each( config, function( val, containerName ) {
+		_.each( val, function( opt, key ) {
+			var dependency = opt;
+			var lifecycle;
+			if ( _.isObject( opt ) ) {
+				if ( opt.scoped ) {
+					lifecycle = 'scoped';
+					dependency = opt.scoped;
+				} else if ( opt.static ) {
+					lifecycle = 'static';
+					dependency = opt.static;
+				} else if ( opt.factory ) {
+					lifecycle = 'factory';
+					dependency = opt.factory;
+				} else {
+					dependency = undefined;
+				}
+			}
+			if ( !dependency ) {
+				dependency = opt;
+				lifecycle = _.isFunction( opt ) ? 'factory' : 'static';
+			}
+			register( containerName, key, dependency, lifecycle );
+		} );
+	} );
+}
+
 function container( name ) {
 	return ( containers[ name ] = containers[ name ] || { scopes: {} } );
+}
+
+function displayDependency( obj ) {
+	if ( _.isFunction( obj ) ) {
+		return obj.name || 'anonymous function';
+	} else if ( _.isString( obj ) || _.isNumber( obj ) || _.isArray( obj ) || _.isDate( obj ) ) {
+		return obj;
+	} else if ( _.isPlainObject( obj ) ) {
+		return '[Object Literal]';
+	} else {
+		return obj.constructor.name || '[Object]';
+	}
+}
+
+function findParent( mod ) {
+	if ( parent ) {
+		return parent;
+	}
+	if ( mod.parent ) {
+		return findParent( mod.parent );
+	} else {
+		parent = mod;
+		return mod;
+	}
+}
+
+function getLoadedModule( name ) {
+	var parent = findParent( module );
+	var regex = new RegExp( name );
+	var candidate = _.find( parent.children, function( child ) {
+		return regex.test( child.id ) && _.contains( child.id.split( '/' ), name );
+	} );
+	if ( candidate ) {
+		candidate.exports.__npm = candidate.exports.__npm || true;
+		return candidate.exports;
+	} else {
+		return undefined;
+	}
+}
+
+function getModuleFromInstalls( name ) {
+	var parent = findParent( module );
+	var installPath = _.find( parent.paths, function( p ) {
+		var modPath = path.join( p, name );
+		return fs.existsSync( modPath );
+	} );
+	var mod;
+	if ( installPath ) {
+		mod = require( path.join( installPath, name ) );
+		mod.__npm = mod.__npm || true;
+	}
+	return mod;
 }
 
 function getArgs( obj ) {
 	return Array.prototype.slice.call( obj );
 }
 
+function getMissingDependencies( containerName, dependencies, scopeName ) {
+	scopeName = scopeName || 'default';
+	containerName = containerName || 'default';
+	dependencies = _.isArray( dependencies ) ? dependencies : [ dependencies ];
+	return _.reduce( dependencies, function( acc, key ) {
+		if ( _.isArray( key ) ) {
+			var ctr = container( containerName );
+			key.forEach( function( k ) {
+				var originalKey = k;
+				var ctrName = containerName;
+				var parts = k.split( /[._]/ );
+				if ( parts.length > 1 ) {
+					ctr = container( parts[ 0 ] );
+					ctrName = parts[ 0 ];
+					k = parts[ 1 ];
+				}
+				if ( !ctr[ k ] && !backfillMissingDependency( key, ctrName ) ) {
+					acc.push( originalKey );
+				}
+			} );
+		} else {
+			var originalKey = key;
+			var parts = key.split( /[._]/ );
+			if ( parts.length > 1 ) {
+				containerName = parts[ 0 ];
+				key = parts[ 1 ];
+			}
+			if ( !container( containerName )[ key ] && !backfillMissingDependency( key, containerName ) ) {
+				acc.push( originalKey );
+			}
+		}
+		return acc;
+	}, [] );
+}
+
 function inject( containerName, dependencies, fn, scopeName ) {
 	scopeName = scopeName || 'default';
-	if( _.isFunction( dependencies ) ) {
+	if ( _.isFunction( dependencies ) ) {
 		scopeName = fn;
 		fn = dependencies;
 		dependencies = [];
 	}
 	dependencies = checkDependencies( fn, dependencies );
+
+	var missingKeys = getMissingDependencies( containerName, dependencies, scopeName );
+	if ( missingKeys.length > 0 ) {
+		throw new Error( util.format( 'Fount could not resolve the following dependencies: %s', missingKeys.join( ', ' ) ) );
+	}
+
 	var args = dependencies.map( function( key ) {
-		var parts = key.split( '.' );
-		if( parts.length > 1 ) {
+		var parts = key.split( /[._]/ );
+		if ( parts.length > 1 ) {
 			containerName = parts[ 0 ];
 			key = parts[ 1 ];
 		}
@@ -63,62 +203,41 @@ function register() {
 	var args = getArgs( arguments );
 	var containerName = args[ 0 ];
 	var key = args[ 1 ];
-	var parts = key.split( '.' );
+	var parts = key.split( /[._]/ );
 	var dependencies = _.isArray( args[ 2 ] ) ? args[ 2 ] : [];
 	var fn = dependencies.length ? args[ 3 ] : args[ 2 ];
 	var lifecycle = ( dependencies.length ? args[ 4 ] : args[ 3 ] ) || 'static';
 
-	if( parts.length > 1 ) {
+	if ( parts.length > 1 ) {
 		containerName = parts[ 0 ];
 		key = parts[ 1 ];
 	}
 
-	if( _.isFunction( fn ) ) {
+
+	if ( _.isFunction( fn ) ) {
 		dependencies = checkDependencies( fn, dependencies );
 	} else {
 		fn = fn || dependencies;
 	}
-	debug( 'Registering key "%s" for container "%s" with %s lifecycle: %s', key, containerName, lifecycle, dependencies, fn );
+	debug( 'Registering key "%s" for container "%s" with %s lifecycle: %s',
+		key, containerName, lifecycle, getDisplay( fn ) );
 	var promise = wrappers[ lifecycle ]( containerName, key, fn, dependencies );
 	container( containerName )[ key ] = promise;
 }
 
-function canResolve( containerName, dependencies, scopeName ) {
-	scopeName = scopeName || 'default';
-	return _.all( dependencies, function( key ) {
-		if( _.isArray( key ) ) {
-			var ctr = container( containerName );
-			var vals = [];
-			key.forEach( function( k ) {
-				var originalKey = k;
-				var parts = k.split( '.' );
-				if( parts.length > 1 ) {
-					ctr = container( parts[ 0 ] );
-					k = parts[ 1 ];
-				}
-				vals.push( ctr[ k ] );
-			} );
-			return _.all( vals );
-		} else {
-			var parts = key.split( '.' );
-			if( parts.length > 1 ) {
-				containerName = parts[ 0 ];
-				key = parts[ 1 ];
-			}
-			return container( containerName )[ key ];
-		}
-	} );
-}
-
 function resolve( containerName, key, scopeName ) {
 	scopeName = scopeName || 'default';
-	if( _.isArray( key ) ) {
-		var ctr = container( containerName );
+	var missingKeys = getMissingDependencies( containerName, key, scopeName );
+	if ( missingKeys.length > 0 ) {
+		throw new Error( util.format( 'Fount could not resolve the following dependencies: %s', missingKeys.join( ', ' ) ) );
+	}
+	if ( _.isArray( key ) ) {
 		var hash = {};
+		var ctr = container( containerName );
 		key.forEach( function( k ) {
 			var originalKey = k;
-			var parts = k.split( '.' );
-			if( parts.length > 1 ) {
+			var parts = k.split( /[._]/ );
+			if ( parts.length > 1 ) {
 				ctr = container( parts[ 0 ] );
 				k = parts[ 1 ];
 			}
@@ -126,13 +245,22 @@ function resolve( containerName, key, scopeName ) {
 		} );
 		return whenKeys.all( hash );
 	} else {
-		var parts = key.split( '.' );
-		if( parts.length > 1 ) {
+		var parts = key.split( /[._]/ );
+		if ( parts.length > 1 ) {
 			containerName = parts[ 0 ];
 			key = parts[ 1 ];
 		}
 		return container( containerName )[ key ]( scopeName );
 	}
+}
+
+function scope( containerName, name ) {
+	var ctr = container( containerName );
+	return ( ctr.scopes[ name ] = ctr.scopes[ name ] || {} );
+}
+
+function setModule( mod ) {
+	parent = mod;
 }
 
 function trimString( str ) {
@@ -142,24 +270,28 @@ function trim( list ) {
 	return ( list && list.length ) ? _.filter( list.map( trimString ) ) : [];
 }
 
-function scope( containerName, name ) {
-	var ctr = container( containerName );
-	return ( ctr.scopes[ name ] = ctr.scopes[ name ] || {} );
+function type( obj ) {
+	return Object.prototype.toString.call( obj );
 }
 
 var wrappers = {
 	factory: function( containerName, key, value, dependencies ) {
 		return function( scopeName ) {
-			if( _.isFunction( value ) && dependencies && canResolve( containerName, dependencies, scopeName ) ) {
-				var args = dependencies.map( function( key ) {
-					return resolve( containerName, key, scopeName );
-				} );
-				return whenFn.apply( value, args );
-			} else {
-				return when.promise( function( resolve ) {
-					resolve( value );
-				} );
+			if ( _.isFunction( value ) ) {
+				var dependencyContainer = containerName;
+				if ( value.__npm ) {
+					dependencyContainer = key;
+				}
+				if ( dependencies && canResolve( dependencyContainer, dependencies, scopeName ) ) {
+					var args = dependencies.map( function( key ) {
+						return resolve( dependencyContainer, key, scopeName );
+					} );
+					return whenFn.apply( value, args );
+				}
 			}
+			return when.promise( function( resolve ) {
+				resolve( value );
+			} );
 		};
 	},
 	scoped: function( containerName, key, value, dependencies ) {
@@ -169,16 +301,16 @@ var wrappers = {
 				cache[ key ] = _.cloneDeep( resolvedTo );
 				return resolvedTo;
 			};
-			if( cache[ key ] ) {
-				return when( cache[ key ] );
-			} else if( _.isFunction( value ) && dependencies && canResolve( containerName, dependencies, scopeName ) ) {
+			if ( cache[ key ] ) {
+				return cache[ key ];
+			} else if ( _.isFunction( value ) && dependencies && canResolve( containerName, dependencies, scopeName ) ) {
 				var args = dependencies.map( function( key ) {
 					return resolve( containerName, key, scopeName );
 				} );
 				return whenFn.apply( value, args ).then( store );
 			} else {
 				return when.promise( function( resolve ) {
-					if( when.isPromiseLike( value ) ) {
+					if ( when.isPromiseLike( value ) ) {
 						value.then( store );
 					} else {
 						store( value );
@@ -190,7 +322,7 @@ var wrappers = {
 	},
 	static: function( containerName, key, value, dependencies ) {
 		var promise;
-		if( _.isFunction( value ) && dependencies && canResolve( containerName, dependencies ) ) {
+		if ( _.isFunction( value ) && dependencies && canResolve( containerName, dependencies ) ) {
 			var args = dependencies.map( function( key ) {
 				return resolve( containerName, key );
 			} );
@@ -205,21 +337,29 @@ var wrappers = {
 };
 
 var fount = function( containerName ) {
-	return {
-		inject: inject.bind( undefined, containerName ),
-		register: register.bind( undefined, containerName ),
-		resolve: resolve.bind( undefined, containerName ),
-		purge: purgeScope.bind( undefined, containerName ),
-		purgeScope: purgeScope.bind( undefined, containerName )
-	};
+	if ( _.isObject( containerName ) ) {
+		configure( containerName );
+	} else {
+		return {
+			canResolve: canResolve.bind( undefined, containerName ),
+			inject: inject.bind( undefined, containerName ),
+			register: register.bind( undefined, containerName ),
+			resolve: resolve.bind( undefined, containerName ),
+			purge: purgeScope.bind( undefined, containerName ),
+			purgeScope: purgeScope.bind( undefined, containerName )
+		};
+	}
 };
 
+fount.canResolve = canResolve.bind( undefined, 'default' );
 fount.inject = inject.bind( undefined, 'default' );
 fount.register = register.bind( undefined, 'default' );
 fount.resolve = resolve.bind( undefined, 'default' );
 fount.purge = purge.bind( undefined );
 fount.purgeAll = purgeAll;
 fount.purgeScope = purgeScope.bind( undefined, 'default' );
+fount.setModule = setModule;
+
 fount.log = function() {
 	console.log( containers );
 };


### PR DESCRIPTION
 * #7 - Add better error reporting - include all unresolvable keys
 * #6 - Export canResolve to allow consumers to check in advance
 * Backfill dependencies from NPM modules when available
 * Add support for bulk registration