### PR TITLE
Version next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.x
+
+### 0.2.0
+
+ * bug fix - inject and resolve across multiple containers now works correctly
+ * functions that can't be resolved in static or scoped lifecycles immediately will be once all dependencies become available
+
 ## 0.1.X
 
 ### 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## 0.2.x
 
 ### 0.2.0
-
  * bug fix - inject and resolve across multiple containers now works correctly
- * functions that can't be resolved in static or scoped lifecycles immediately will be once all dependencies become available
- * don't backfill dependencies from NPM for non-default containers
+ * improvement - functions that can't be resolved in static or scoped lifecycles immediately will be once all dependencies become available
+ * feature - add a way to register function as value without a wrapper
+ * NPM modules
+ 	* don't auto-backfill dependencies from NPM anymore, it's kinda gross
+ 	* provide ability to grab an "ambient" module from the require cache
 
 ## 0.1.X
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  * bug fix - inject and resolve across multiple containers now works correctly
  * functions that can't be resolved in static or scoped lifecycles immediately will be once all dependencies become available
+ * don't backfill dependencies from NPM for non-default containers
 
 ## 0.1.X
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ You may want to register a function as a value (confused yet?) so that fount ret
 fount.register( 'calculator', function() { return function( x, y ) { return x + y; }; } );
 ```
 
+__OR__
+
+```javascript
+// this really is just wrapping the value in a function like above, but it's easier to read
+// and hopefully less frustrating
+fount.registerAsValue( 'calculator', function( x, y ) { return x + y; } );
+```
+
 ### promise
 Registering a promise looks almost identical to registering a function. From a consuming perspective, they're functionally equivalent since fount will wrap raw function execution in a promise anyway.
 
@@ -120,6 +128,23 @@ Registering a promise looks almost identical to registering a function. From a c
 fount.register( 'todo', when.promise( function( reject, resolve ) {
 	resolve( 'done' );
 } ) );
+```
+
+### NPM modules
+Fount will allow you to plug in an NPM module. If the module was previously loaded, it will grab it from the require cache, otherwise, it will attempt to load it from the modules folder:
+
+> Note: this method will register modules that return a function as a factory which will be invoked anytime the module is resolved as a dependency
+
+```javascript
+fount.registerModule( "when" );
+```
+
+In the example above, where `when` is regsitered, fount will see that it is a function and register it as a factory. During resolve time, because fount cannot resolve the argument list for `when`'s function, it will simply provide the `when` function as the value.
+
+```javascript
+fount.inject( function( when ) {
+	return when( "this works as you'd expect" );
+} );
 ```
 
 ## Resolving
@@ -201,6 +226,32 @@ fount( {
 			} }
 	}
 } );
+```
+
+## Purge
+Fount provides three different ways to clean up:
+ * ejecting all keys and resolved scope values from all containers
+ * ejecting all keys and resolved scope values from one container
+ * removing all resolved scoped values from one container
+
+> Note: purge doesn't support the `_` or `.` delimited syntax for containers. When purging non-default containers, select the container first like in the examples below:
+
+```javascript
+// this is like starting from scratch:
+fount.purgeAll();
+
+// remove all values for the default container's custom scope
+// this does not remove the keys, just their resolved values
+fount.purgeScope( "custom" );
+
+// eject all keys from the default container
+fount.purge();
+
+// remove all values for the myContainer's custom scope
+fount( "myContainer" ).purgeScope( "custom" );
+
+// eject all keys from myContainer
+fount( "myContainer" ).purge();
 ```
 
 ## Diagnostic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fount",
-  "version": "0.1.0",
+  "version": "0.2.0-1",
   "description": "A source from which dependencies flow",
   "main": "./src/index.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "chai-as-promised": "~4.3.0",
     "gulp": "~3.8.11",
     "postal": "^1.0.2",
-    "sinon": "~1.14.1"
+    "sinon": "~1.14.1",
+    "whistlepunk": "^0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fount",
-  "version": "0.2.0-1",
+  "version": "0.2.0-2",
   "description": "A source from which dependencies flow",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fount",
-  "version": "0.2.0-2",
+  "version": "0.1.1",
   "description": "A source from which dependencies flow",
   "main": "./src/index.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "injection"
   ],
   "author": "Alex Robson",
-  "license": "MIT License (http://opensource.org/licenses/MIT)",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/LeanKit-Labs/fount/issues"
   },

--- a/spec/inject.spec.js
+++ b/spec/inject.spec.js
@@ -178,6 +178,20 @@ describe( 'Injecting', function() {
 				result.should.equal( 20 );
 			} );
 		} );
+
+		describe( 'when injecting from multiple containers', function() {
+			before( function() {
+				fount.register( 'three.a', 3 );
+				fount( 'three' ).register( 'b', 4 );
+				fount.register( 'four.c', 5 );
+			} );
+
+			it( 'should resolve to correct values', function() {
+				fount.inject( [ 'three.a', 'three.b', 'four.c' ], function( x, y, z ) {
+					return x + y + z;
+				} ).should.eventually.eql( 12 );
+			} );
+		} );
 	} );
 
 	describe( 'when injecting without dependency array', function() {
@@ -200,6 +214,21 @@ describe( 'Injecting', function() {
 
 			it( 'should return array of correct values', function() {
 				results.should.eql( [ 1, 2, 3 ] );
+			} );
+		} );
+
+		describe( 'when resolving across multiple containers', function() {
+			before( function() {
+				fount.register( 'three.a', 3 );
+				fount( 'three' ).register( 'b', 4 );
+				fount( 'three' ).register( 'c', 4.5 );
+				fount.register( 'four.c', 5 );
+			} );
+
+			it( 'should resolve correct values', function() {
+				fount.inject( function( three_a, three_b, four_c ) {
+					return three_a + three_b + four_c;
+				} ).should.eventually.eql( 12 );
 			} );
 		} );
 	} );

--- a/spec/module.spec.js
+++ b/spec/module.spec.js
@@ -6,6 +6,10 @@ describe( 'NPM Dependencies', function() {
 
 	describe( 'when require cache has dependency', function() {
 		describe( 'with static dependency', function() {
+			before( function() {
+				fount.registerModule( 'postal' );
+			} );
+
 			it( 'should successfully register as static', function() {
 				return fount.resolve( 'postal' ).should.eventually.equal( postal );
 			} );
@@ -21,6 +25,10 @@ describe( 'NPM Dependencies', function() {
 
 	describe( 'when require cache does not have dependency', function() {
 		describe( 'with factory dependency', function() {
+			before( function() {
+				fount.registerModule( 'whistlepunk' );
+			} );
+
 			it( 'should successfully register as factory', function() {
 				return fount.resolve( 'whistlepunk' )
 					.should.eventually.equal( require( 'whistlepunk' ) );

--- a/spec/resolve.spec.js
+++ b/spec/resolve.spec.js
@@ -53,18 +53,37 @@ describe( 'Resolving', function() {
 	describe( 'when resolving functions', function() {
 
 		describe( 'without dependencies', function() {
-			before( function() {
-				fount.register( 'simpleFn', function() {
-					return 'hello, world!';
+			describe( 'when registered normally', function() {
+				before( function() {
+					fount.register( 'simpleFn', function() {
+						return 'hello, world!';
+					} );
+				} );
+
+				it( 'should resolve the function\'s result', function() {
+					this.timeout( 100 );
+					fount.resolve( 'simpleFn' )
+						.should.eventually.equal( 'hello, world!' );
 				} );
 			} );
 
-			it( 'should resolve the function\'s result', function() {
-				this.timeout( 100 );
-				fount.resolve( 'simpleFn' )
-					.should.eventually.equal( 'hello, world!' );
+			describe( 'when registered as a value', function() {
+				before( function() {
+					fount.registerAsValue( 'simpleFn2', function() {
+						return 'hello, world!';
+					} );
+				} );
+
+				it( 'should resolve to the function', function() {
+					this.timeout( 100 );
+					fount.resolve( 'simpleFn2' )
+						.then( function( fn ) { return fn(); } )
+						.should.eventually.equal( 'hello, world!' );
+				} );
 			} );
 		} );
+
+
 
 		describe( 'with dependency on a list', function() {
 			before( function() {

--- a/spec/resolve.spec.js
+++ b/spec/resolve.spec.js
@@ -95,8 +95,45 @@ describe( 'Resolving', function() {
 			} );
 
 			it( 'should resolve function\'s dependencies', function() {
-				fount.resolve( 'line' )
+				return fount.resolve( 'line' )
 					.should.eventually.equal( 'easy as 1, 2, 3!' );
+			} );
+		} );
+
+		describe( 'with initially unmet dependencies', function() {
+			var calls = 0;
+			function delayed( a2, b2, c2 ) {
+				calls ++;
+				return a2 + b2 + c2;
+			}
+			before( function() {
+				fount.register( 'delayed', delayed );
+			} );
+
+			it( 'should resolve to the function if called before dependencies are registered', function() {
+				return fount.resolve( 'delayed' )
+					.should.eventually.eql( delayed );
+			} );
+
+			describe( 'after dependencies are registered', function() {
+				before( function() {
+					fount.register( 'a2', 1 );
+					fount.register( 'b2', 10 );
+					fount.register( 'c2', 100 );
+				} );
+
+				it( 'should resolve to function result', function() {
+					return fount.resolve( 'delayed' )
+						.should.eventually.eql( 111 );
+				} );
+
+				it( 'should not call function after initial resolution', function() {
+					return fount.resolve( 'delayed' )
+						.then( function () {
+							return calls;
+						} )
+						.should.eventually.eql( 1 );
+				} );
 			} );
 		} );
 
@@ -106,7 +143,7 @@ describe( 'Resolving', function() {
 			} );
 
 			it( 'should resolve to original value', function() {
-				fount.resolve( 'line' )
+				return fount.resolve( 'line' )
 					.should.eventually.equal( 'easy as 1, 2, 3!' );
 			} );
 		} );
@@ -132,7 +169,6 @@ describe( 'Resolving', function() {
 			} );
 		} );
 
-
 		describe( 'with multiple scopes', function() {
 			var obj = { x: 1 };
 			describe( 'in scope default', function() {
@@ -147,7 +183,7 @@ describe( 'Resolving', function() {
 				} );
 
 				it( 'should resolve correctly', function() {
-					fount.resolve( [ 'o', 'getX' ] )
+					return fount.resolve( [ 'o', 'getX' ] )
 						.should.eventually.eql( { 'o': { x: 1 }, 'getX': 1 } );
 				} );
 			} );
@@ -158,14 +194,14 @@ describe( 'Resolving', function() {
 				} );
 
 				it( 'should resolve indepedent results', function() {
-					fount.resolve( [ 'o', 'getX' ], 'custom' )
+					return fount.resolve( [ 'o', 'getX' ], 'custom' )
 						.should.eventually.eql( { 'o': { x: 10 }, 'getX': 10 } );
 				} );
 			} );
 
 			describe( 'back to default', function() {
 				it( 'should resolve original scoped results', function() {
-					fount.resolve( [ 'o', 'getX' ] )
+					return fount.resolve( [ 'o', 'getX' ] )
 						.should.eventually.eql( { 'o': { x: 1 }, 'getX': 1 } );
 				} );
 			} );
@@ -205,6 +241,12 @@ describe( 'Resolving', function() {
 				var result;
 				before( function() {
 					fount.register( 'met', 'true' );
+					fount.register( 'one.a', 1 );
+					fount( 'two' ).register( 'b', 2 );
+				} );
+
+				it( 'should correctly resolve a check across multiple containers', function() {
+					fount.canResolve( [ 'one.a', 'two.b' ] ).should.equal( true );
 				} );
 
 				it( 'should resolve existing dependency', function() {
@@ -224,5 +266,28 @@ describe( 'Resolving', function() {
 				}, 'Fount could not resolve the following dependencies: lol, rofl' );
 			} );
 		} );
+	} );
+
+	describe( 'when resolving across multiple containers', function() {
+		before( function() {
+			fount.register( 'three.a', 3 );
+			fount( 'three' ).register( 'b', 4 );
+			fount( 'three' ).register( 'c', 4.5 );
+			fount.register( 'four.c', 5 );
+		} );
+
+		it( 'should resolve correct values', function() {
+			fount.resolve( [ 'three.a', 'three.b', 'four.c' ], function( results ) {
+				return results;
+			} ).should.eventually.eql( {
+				'three.a': 3,
+				'three.b': 4,
+				'four.c': 5
+			} );
+		} );
+	} );
+
+	after( function() {
+		fount.purgeAll();
 	} );
 } );

--- a/spec/resolve.spec.js
+++ b/spec/resolve.spec.js
@@ -256,6 +256,10 @@ describe( 'Resolving', function() {
 				it( 'should not resolve missing dependency', function() {
 					fount.canResolve( 'unmet' ).should.equal( false );
 				} );
+
+				it( 'should not resolve missing dependency in non-default container from NPM', function() {
+					fount.canResolve( "special.when" ).should.equal( false );
+				} );
 			} );
 		} );
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ var parent;
 var getDisplay = process.env.DEBUG ? displayDependency : _.noop;
 
 function backfillMissingDependency( name, containerName ) {
-	var mod = getLoadedModule( name ) || getModuleFromInstalls( name );
+	var mod = getLoadedModule( name ) || ( containerName === "default" ? getModuleFromInstalls( name ) : null );
 	if ( mod ) {
 		var lifecycle = _.isFunction( mod ) ? 'factory' : 'static';
 		register( containerName, name, mod, lifecycle );


### PR DESCRIPTION
This would introduce fount 0.2.0:
* bug fix - inject and resolve across multiple containers now works correctly
* improvement - functions that can't be resolved in static or scoped lifecycles immediately will be once all dependencies become available
* feature - add a way to register function as value without a wrapper
* NPM modules
 	* don't auto-backfill dependencies from NPM anymore, it's kinda gross
 	* provide ability to grab an "ambient" module from the require cache